### PR TITLE
Collect functions / identifiers from expressions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{ts,js}]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,5 @@ root = true
 [*.{ts,js}]
 indent_style = space
 indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -8,7 +8,7 @@ import {unique, cache, Obj} from '@mathigon/core';
 import {nearlyEquals} from '@mathigon/fermat';
 import {ExprElement} from './elements';
 import {CONSTANTS} from './symbols';
-import {tokenize, matchBrackets} from './parser';
+import {tokenize, matchBrackets, inferTermTypes} from './parser';
 
 
 /** Parses a string to an expression. */
@@ -50,4 +50,5 @@ function numEquals(expr1: ExprElement, expr2: ExprElement) {
 export const Expression = {
   numEquals,
   parse: cache(parse),
+  inferTermTypes,
 };

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -11,9 +11,14 @@ import {CONSTANTS} from './symbols';
 import {tokenize, matchBrackets, inferTermTypes} from './parser';
 
 
-/** Parses a string to an expression. */
-function parse(str: string, collapse = false) {
-  const expr = matchBrackets(tokenize(str));
+/**
+ * Parses a string to an expression.
+ *
+ * If `context` is supplied, interpret `f(a+b)` as `f*(a+b)` if `f` is in
+ * `context.identifiers`.
+ */
+function parse(str: string, collapse = false, context?: {fns?: Set<string>, identifiers?: Set<string>}) {
+  const expr = matchBrackets(tokenize(str), context);
   return collapse ? expr.collapse() : expr;
 }
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -15,9 +15,9 @@ import {tokenize, matchBrackets} from './parser';
  * Parses a string to an expression.
  *
  * If `context` is supplied, interpret `f(a+b)` as `f*(a+b)` if `f` is in
- * `context.identifiers`.
+ * `context.variables`.
  */
-function parse(str: string, collapse = false, context?: {fns?: Set<string>, identifiers?: Set<string>}) {
+function parse(str: string, collapse = false, context?: {variables?: string[]}) {
   const expr = matchBrackets(tokenize(str), context);
   return collapse ? expr.collapse() : expr;
 }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -8,7 +8,7 @@ import {unique, cache, Obj} from '@mathigon/core';
 import {nearlyEquals} from '@mathigon/fermat';
 import {ExprElement} from './elements';
 import {CONSTANTS} from './symbols';
-import {tokenize, matchBrackets, inferTermTypes} from './parser';
+import {tokenize, matchBrackets} from './parser';
 
 
 /**
@@ -55,5 +55,4 @@ function numEquals(expr1: ExprElement, expr2: ExprElement) {
 export const Expression = {
   numEquals,
   parse: cache(parse),
-  inferTermTypes,
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -291,3 +291,21 @@ export function collapseTerm(tokens: ExprElement[]) {
   if (tokens.length > 1) throw ExprError.invalidExpression();
   return tokens[0];
 }
+
+export function inferTermTypes(e: ExprElement): {fns: Set<string>, identifiers: Set<string>} {
+  const fns = new Set<string>();
+  const identifiers = new Set<string>();
+  const collectTerm = (terms: ExprElement[]) => {
+    for (const term of terms) {
+      if (term instanceof ExprIdentifier) {
+        identifiers.add(term.i);
+      } else if (term instanceof ExprFunction) {
+        fns.add(term.fn);
+        collectTerm(term.args);
+      }
+    }
+  };
+  collectTerm([e]);
+
+  return {fns, identifiers};
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -190,7 +190,7 @@ export function matchBrackets(tokens: ExprElement[], context?: {fns?: Set<string
       const closed = stack.pop();
       const term = last(stack);
 
-      const safeIdentifiers = (context && context.identifiers) || new Set([]);
+      const safeIdentifiers = context?.identifiers || new Set([]);
 
       // Check if this is a normal bracket, or a function call.
       // Terms like x(y) are treated as functions, rather than implicit
@@ -295,22 +295,4 @@ export function collapseTerm(tokens: ExprElement[]) {
 
   if (tokens.length > 1) throw ExprError.invalidExpression();
   return tokens[0];
-}
-
-export function inferTermTypes(e: ExprElement): {fns: Set<string>, identifiers: Set<string>} {
-  const fns = new Set<string>();
-  const identifiers = new Set<string>();
-  const collectTerm = (terms: ExprElement[]) => {
-    for (const term of terms) {
-      if (term instanceof ExprIdentifier) {
-        identifiers.add(term.i);
-      } else if (term instanceof ExprFunction) {
-        fns.add(term.fn);
-        collectTerm(term.args);
-      }
-    }
-  };
-  collectTerm([e]);
-
-  return {fns, identifiers};
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -175,7 +175,7 @@ function prepareTerm(tokens: ExprElement[]) {
   return makeTerm(tokens);
 }
 
-export function matchBrackets(tokens: ExprElement[]) {
+export function matchBrackets(tokens: ExprElement[], context?: {fns?: Set<string>, identifiers?: Set<string>}) {
   const stack: ExprElement[][] = [[]];
 
   for (const t of tokens) {
@@ -190,11 +190,16 @@ export function matchBrackets(tokens: ExprElement[]) {
       const closed = stack.pop();
       const term = last(stack);
 
+      const safeIdentifiers = (context && context.identifiers) || new Set([]);
+
       // Check if this is a normal bracket, or a function call.
       // Terms like x(y) are treated as functions, rather than implicit
-      // multiplication, except for π(y).
+      // multiplication, except for π(y) and terms explicitly included in
+      // context.identifiers
       const isFn = (isOperator(t, ')') && last(term) instanceof ExprIdentifier &&
+                    !safeIdentifiers.has((last(term) as ExprIdentifier).i) &&
                     (last(term) as ExprIdentifier).i !== 'π');
+
       const fnName = isFn ? (term.pop() as ExprIdentifier).i : (closed![0] as ExprOperator).o;
 
       // Support multiple arguments for function calls.

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -94,3 +94,11 @@ tape('inference', (test) => {
   test.ok(setEquals(new Set(['a', 'b']), terms.identifiers));
   test.end();
 });
+
+tape('context', (test) => {
+  const solution = expr('2x*(a+b)').collapse();
+  const context = Expression.inferTermTypes(solution);
+  const student = Expression.parse('2x(a+b)', false, context).collapse();
+  test.equals(student.toString(), solution.toString());
+  test.end();
+});

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -85,3 +85,12 @@ tape('errors', (test) => {
   test.throws(() => expr('(+) - a').collapse());
   test.end();
 });
+
+const setEquals = <T>(l: Set<T>, r: Set<T>) => l.size === r.size && Array.from(l).every(e => r.has(e));
+
+tape('inference', (test) => {
+  const terms = Expression.inferTermTypes(expr('f(a+b)').collapse());
+  test.ok(setEquals(new Set(['f', '+']), terms.fns));
+  test.ok(setEquals(new Set(['a', 'b']), terms.identifiers));
+  test.end();
+});

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -86,19 +86,16 @@ tape('errors', (test) => {
   test.end();
 });
 
-const setEquals = <T>(l: Set<T>, r: Array<T>) =>
-  l.size === r.length && Array.from(l).every(e => r.includes(e));
-
-tape('inference', (test) => {
-  const terms = expr('f(a+b)').collapse();
-  test.ok(setEquals(new Set(['f', '+']), terms.functions));
-  test.ok(setEquals(new Set(['a', 'b']), terms.variables));
+tape('extract functions and variables', (test) => {
+  const terms = expr('x * f(a+b)').collapse();
+  test.same(terms.functions, ['×', 'f', '+']);
+  test.same(terms.variables, ['x', 'a', 'b']);
   test.end();
 });
 
 tape('context', (test) => {
   const solution = expr('2x*(a+b)').collapse();
-  const context = {fns: new Set(solution.functions), identifiers: new Set(solution.variables)};
+  const context = {variables: solution.variables};
   const student = Expression.parse('2x(a+b)', false, context).collapse();
   test.equals(student.toString(), solution.toString());
   test.end();

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -86,18 +86,19 @@ tape('errors', (test) => {
   test.end();
 });
 
-const setEquals = <T>(l: Set<T>, r: Set<T>) => l.size === r.size && Array.from(l).every(e => r.has(e));
+const setEquals = <T>(l: Set<T>, r: Array<T>) =>
+  l.size === r.length && Array.from(l).every(e => r.includes(e));
 
 tape('inference', (test) => {
-  const terms = Expression.inferTermTypes(expr('f(a+b)').collapse());
-  test.ok(setEquals(new Set(['f', '+']), terms.fns));
-  test.ok(setEquals(new Set(['a', 'b']), terms.identifiers));
+  const terms = expr('f(a+b)').collapse();
+  test.ok(setEquals(new Set(['f', '+']), terms.functions));
+  test.ok(setEquals(new Set(['a', 'b']), terms.variables));
   test.end();
 });
 
 tape('context', (test) => {
   const solution = expr('2x*(a+b)').collapse();
-  const context = Expression.inferTermTypes(solution);
+  const context = {fns: new Set(solution.functions), identifiers: new Set(solution.variables)};
   const student = Expression.parse('2x(a+b)', false, context).collapse();
   test.equals(student.toString(), solution.toString());
   test.end();


### PR DESCRIPTION
Precursor to #13 without needing authors to supply a context to any solutions.

Todo (probably separate PRs):
- work out where `x-equation` parses student input and compares them to solutions (I don't see any trace of `evaluate` in textbooks/ - @plegner, could you give me a hint?), then take author-provided solutions and extract context from them using this function
- [x] use that context in https://github.com/mathigon/hilbert.js/blob/8818fb277e791d31769ef4744a7e760a411d354a/src/parser.ts#L196 (with default behaviour with no context staying the same as it currently is)


Marked as draft as I hate the name `inferTermTypes` + I'm personally of the opinion that code shouldn't be merged until it is used.