### PR TITLE
WIP: Matrices, piece-wise, summation, product integrals

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -5,7 +5,7 @@
 
 
 import {total} from '@mathigon/core';
-import {gcd, isBetween, lcm} from '@mathigon/fermat';
+import {gcd, isBetween, lcm, nearlyEquals} from '@mathigon/fermat';
 import {SpecialFunction} from './symbols';
 
 const OPERATORS = ['add', 'sub', 'mul', 'div', 'sup'] as const;
@@ -36,6 +36,12 @@ export const hasZero = (a: Interval) => contains(a, 0);
 
 // -----------------------------------------------------------------------------
 // Standard Evaluation
+
+export const evaluateRel: Record<'='|'<'|'>', (...args: number[]) => boolean> = {
+  '=': (a, b) => nearlyEquals(a, b),
+  '<': (a, b) => a < b,
+  '>': (a, b) => a > b
+};
 
 export const evaluate: Record<Functions, (...args: number[]) => number> = {
   add: (...args) => args.reduce((a, b) => a + b, 0),
@@ -118,6 +124,12 @@ function intervalMod(a: Interval, m = TWO_PI): Interval {
 
 // -----------------------------------------------------------------------------
 // Interval Evaluation
+
+export const intervalRel: Record<'='|'<'|'>', (...args: Interval[]) => boolean> = {
+  '=': (a, b) => (contains(a, b[0]) && contains(a, b[1])) || (contains(b, a[0]) && contains(b, a[1])),
+  '<': (a, b) => a[1] < b[0],
+  '>': (a, b) => a[1] < b[0]
+};
 
 export const interval: Record<Functions, (...args: Interval[]) => Interval> = {
   add: (...args) => int(total(args.map(a => a[0])), total(args.map(a => a[1]))),

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -209,7 +209,8 @@ export class ExprFunction extends ExprElement {
 
     if (isOneOf(this.fn, '(', '[', '{')) {
       const join = this.fn === '(' ? COMMA : '';
-      return `<mfenced open="${this.fn}" close="${BRACKETS[this.fn]}">${argsF.join(join)}</mfenced>`;
+      const rows = this.args.filter(r => r.toString() === ';').length + 1;
+      return `<mfenced open="${this.fn}" close="${BRACKETS[this.fn]}" rows="${rows}">${argsF.join(join)}</mfenced>`;
     }
 
     if (isOneOf(this.fn, '!', '%')) {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -263,7 +263,17 @@ export class ExprFunction extends ExprElement {
     if (this.fn === 'sub') return joined;
     if (this.fn === 'subsup') return `${args[0]} ${args[1]} ${supVoice(args[2])}`;
     if (this.fn === 'sup') return `${args[0]} ${supVoice(args[1])}`;
-
+    if (this.fn === 'underover') {
+      let symbol = '?';
+      if (args[0] === '∑') {
+        symbol = 'sum';
+      } else if (args[0] === '∫') {
+        symbol = 'integral';
+      } else if (args[0] === '∏') {
+        symbol = 'product';
+      }
+      return `${symbol} from ${args[1]} to ${args[2]} of`;
+    }
     if (VOICE_STRINGS[this.fn]) return args.join(` ${VOICE_STRINGS[this.fn]} `);
     // TODO Implement other cases
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -250,6 +250,8 @@ export class ExprFunction extends ExprElement {
     // Maybe `open bracket ${joined} close bracket` ?
 
     if (this.fn === 'sqrt') return `square root of ${joined}`;
+    if (this.fn === 'root' && args[1] === '3') return `cubic root of ${args[0]}`;
+    if (this.fn === 'root' && args[1] !== '3') return `${args[1]}th root of ${[args[0]]}`;
     if (this.fn === '%') return `${joined} percent`;
     if (this.fn === '!') return `${joined} factorial`;
     if (this.fn === '/') return `${args[0]} over ${args[1]}`;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -188,7 +188,7 @@ export class ExprFunction extends ExprElement {
     if (this.fn === 'sqrt') return `<msqrt>${argsF[0]}</msqrt>`;
 
     if (isOneOf(this.fn, '/', 'root')) {
-      // Fractions or square roots don't have brackets around their arguments
+      // Fractions or roots don't have brackets around their arguments
       const el = (this.fn === '/' ? 'mfrac' : 'mroot');
       const args1 = this.args.map((a, i) => addMRow(a, args[i]));
       return `<${el}>${args1.join('')}</${el}>`;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -171,6 +171,7 @@ export class ExprFunction extends ExprElement {
   }
 
   toMathML(custom: MathMLMap = {}) {
+    // Remove matrix/piecewise row breaks by filtering semi-colons.
     const args = this.args.filter(a => a.toString() !== ';').map(a => a.toMathML(custom));
     const argsF = this.args.filter(a => a.toString() !== ';').map((a, i) => addMFence(a, this.fn, args[i]));
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -207,10 +207,13 @@ export class ExprFunction extends ExprElement {
       return `<m${this.fn}>${args1.join('')}</m${this.fn}>`;
     }
 
-    if (isOneOf(this.fn, '(', '[', '{')) {
-      const join = this.fn === '(' ? COMMA : '';
+    if (this.fn === '(') {
+      return `<mfenced open="${this.fn}" close="${BRACKETS[this.fn]}">${argsF.join(COMMA)}</mfenced>`;
+    }
+
+    if (isOneOf(this.fn, '[', '{')) {
       const rows = this.args.filter(r => r.toString() === ';').length + 1;
-      return `<mfenced open="${this.fn}" close="${BRACKETS[this.fn]}" rows="${rows}">${argsF.join(join)}</mfenced>`;
+      return `<mfenced open="${this.fn}" close="${BRACKETS[this.fn]}" rows="${rows}">${argsF.join('')}</mfenced>`;
     }
 
     if (isOneOf(this.fn, '!', '%')) {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -201,10 +201,10 @@ export class ExprFunction extends ExprElement {
       return `<m${this.fn}>${args1.join('')}</m${this.fn}>`;
     }
 
-    if (this.fn === 'subsup') {
+    if (this.fn === 'subsup' || this.fn === 'underover') {
       const args1 = [addMRow(this.args[0], argsF[0]),
         addMRow(this.args[1], args[1]), addMRow(this.args[2], args[2])];
-      return `<msubsup>${args1.join('')}</msubsup>`;
+      return `<m${this.fn}>${args1.join('')}</m${this.fn}>`;
     }
 
     if (isOneOf(this.fn, '(', '[', '{')) {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -73,6 +73,24 @@ export class ExprFunction extends ExprElement {
     }
 
     if ('=<>'.includes(this.fn)) return evaluateRel[this.fn as '='|'<'|'>'](...args) ? 1 : 0;
+    // TODO: evaluate underover functions
+    // if (this.fn === 'underover') {
+    //   if (this.args[0].toString() === '∑') {
+    //     let sum = 0;
+    //     for (let i = args[1]; i < args[2]; i++) {
+    //       sum += i;
+    //     }
+    //     return sum;
+    //   }
+    //   if (this.args[0].toString() === '∏') {
+    //     let prod = 1;
+    //     for (let i = args[1]; i < args[2]; i++) {
+    //       prod *= i;
+    //     }
+    //     return prod;
+    //   }
+    // }
+    //
     if (this.operator) return evaluate[this.operator](...args);
     throw ExprError.undefinedFunction(this.fn);
   }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -153,8 +153,8 @@ export class ExprFunction extends ExprElement {
   }
 
   toMathML(custom: MathMLMap = {}) {
-    const args = this.args.map(a => a.toMathML(custom));
-    const argsF = this.args.map((a, i) => addMFence(a, this.fn, args[i]));
+    const args = this.args.filter(a => a.toString() !== ';').map(a => a.toMathML(custom));
+    const argsF = this.args.filter(a => a.toString() !== ';').map((a, i) => addMFence(a, this.fn, args[i]));
 
     if (this.fn in custom) {
       const argsX = args.map((a, i) => ({

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -130,6 +130,8 @@ function findBinaryFunction(tokens: ExprElement[], fn: string) {
   if (isOperator(tokens[0], fn)) throw ExprError.startOperator(tokens[0]);
   if (isOperator(last(tokens), fn)) throw ExprError.endOperator(last(tokens));
 
+  const mUnderOver = ['∑', '∏'];
+
   for (let i = 1; i < tokens.length - 1; ++i) {
     if (!isOperator(tokens[i], fn)) continue;
     const token = tokens[i] as ExprOperator;
@@ -137,7 +139,8 @@ function findBinaryFunction(tokens: ExprElement[], fn: string) {
     const a = tokens[i - 1];
     const b = tokens[i + 1];
 
-    if (a instanceof ExprOperator) {
+    // Sigma is ExprOperator, next to '_' also an operator
+    if (a instanceof ExprOperator && !mUnderOver.includes(a.o)) {
       throw ExprError.consecutiveOperators(a.o, token.o);
     }
     if (b instanceof ExprOperator) {
@@ -151,7 +154,8 @@ function findBinaryFunction(tokens: ExprElement[], fn: string) {
       if (c instanceof ExprOperator) throw ExprError.consecutiveOperators(token2.o, c.o);
       const args = [removeBrackets(a), removeBrackets(b), removeBrackets(c)];
       if (token.o === '^') [args[1], args[2]] = [args[2], args[1]];
-      tokens.splice(i - 1, 5, new ExprFunction('subsup', args));
+      const mathMLFn = mUnderOver.includes(a.toString()) ? 'underover' : 'subsup';
+      tokens.splice(i - 1, 5, new ExprFunction(mathMLFn, args));
       i -= 4;
 
     } else {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -195,13 +195,14 @@ export function matchBrackets(tokens: ExprElement[], context?: {variables?: stri
       }
 
       const closed = stack.pop();
+      if (closed === undefined) continue;
       const term = last(stack);
 
       const lastTerm = last(term);
       const isFn = isOperator(t, ')') && lastTerm instanceof ExprIdentifier &&
         !safeVariables.includes(lastTerm.i);
 
-      const fnName = isFn ? (term.pop() as ExprIdentifier).i : (closed![0] as ExprOperator).o;
+      const fnName = isFn ? (term.pop() as ExprIdentifier).i : (closed[0] as ExprOperator).o;
 
       // Support multiple arguments for function calls.
       const args = splitArray(closed!.slice(1), a => isOperator(a, ', ;'));

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -200,8 +200,9 @@ export function matchBrackets(tokens: ExprElement[], context?: {variables?: stri
       const fnName = isFn ? (term.pop() as ExprIdentifier).i : (closed![0] as ExprOperator).o;
 
       // Support multiple arguments for function calls.
-      const args = splitArray(closed!.slice(1), a => isOperator(a, ','));
+      const args = splitArray(closed!.slice(1), a => isOperator(a, ', ;'));
       term.push(new ExprFunction(fnName, args.map(prepareTerm)));
+      // TODO Tell ExprFunction how many rows/columns there are in the matrix
 
     } else if (isOperator(t, '( [ {')) {
       stack.push([t]);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -205,9 +205,17 @@ export function matchBrackets(tokens: ExprElement[], context?: {variables?: stri
       const fnName = isFn ? (term.pop() as ExprIdentifier).i : (closed[0] as ExprOperator).o;
 
       // Support multiple arguments for function calls.
-      const args = splitArray(closed!.slice(1), a => isOperator(a, ', ;'));
+      const withinBrackets = closed.slice(1);
+      const args = splitArray(withinBrackets, a => isOperator(a, ', ;'));
+
+      // Conditionally re-add semicolon row break markers for matrices
+      for (let i = 0; i < withinBrackets.length; i++) {
+        if (withinBrackets[i].toString() === ';' && isOperator(t, '] }')) {
+          args.splice(i - 1, 0, [withinBrackets[i]]);
+        }
+      }
+
       term.push(new ExprFunction(fnName, args.map(prepareTerm)));
-      // TODO Tell ExprFunction how many rows/columns there are in the matrix
 
     } else if (isOperator(t, '( [ {')) {
       stack.push([t]);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -130,7 +130,7 @@ function findBinaryFunction(tokens: ExprElement[], fn: string) {
   if (isOperator(tokens[0], fn)) throw ExprError.startOperator(tokens[0]);
   if (isOperator(last(tokens), fn)) throw ExprError.endOperator(last(tokens));
 
-  const mUnderOver = ['∑', '∏'];
+  const mUnderOver = ['∑', '∏', '∫'];
 
   for (let i = 1; i < tokens.length - 1; ++i) {
     if (!isOperator(tokens[i], fn)) continue;

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -112,7 +112,7 @@ const UPPERCASE = ALPHABET.toUpperCase().split('');
 const GREEK = Object.values(SPECIAL_IDENTIFIERS);
 export const IDENTIFIER_SYMBOLS = [...LOWERCASE, ...UPPERCASE, ...GREEK, '$'];
 
-const SIMPLE_SYMBOLS = '|()[]{}÷,!<>=*/+-–−~^_…°•∥⊥\'∠:%∼△';
+const SIMPLE_SYMBOLS = '|()[]{}÷,;!<>=*/+-–−~^_…°•∥⊥\'∠:%∼△';
 const COMPLEX_SYMBOLS = Object.values(SPECIAL_OPERATORS);
 export const OPERATOR_SYMBOLS = [...SIMPLE_SYMBOLS, ...COMPLEX_SYMBOLS];
 

--- a/test/evaluate-test.ts
+++ b/test/evaluate-test.ts
@@ -27,6 +27,8 @@ tape('Functions', (test) => {
   test.equal(value('2 ^ 3'), 8);
   test.equal(value('4 / 2'), 2);
   test.equal(value('sqrt(81)'), 9);
+  test.equal(value('root(27, 3)'), 3);
+  test.equal(value('root(81, 4)'), 3);
   test.equal(Math.round(value('sin(pi)')), 0);
   test.end();
 });

--- a/test/mathml-test.ts
+++ b/test/mathml-test.ts
@@ -163,7 +163,7 @@ tape('Matrices and Piecewise', (test) => {
 
 tape('Under Over', (test) => {
   test.equal(mathML('∑_(i = 0)^2 i'),
-    '<munderover><mo value="∑">∑</mo><mrow><mi>i</mi><mo value="=">=</mo><mn>0</mn>∫</mrow><mn>2</mn></munderover><mi>i</mi>');
+    '<munderover><mo value="∑">∑</mo><mrow><mi>i</mi><mo value="=">=</mo><mn>0</mn></mrow><mn>2</mn></munderover><mi>i</mi>');
   test.equal(mathML('∫_a^b c'),
     '<munderover><mo value="∫">∫</mo><mi>a</mi><mi>b</mi></munderover><mi>c</mi>');
   test.equal(mathML('∫_0^1 xdx'),

--- a/test/mathml-test.ts
+++ b/test/mathml-test.ts
@@ -128,8 +128,6 @@ tape('Roots', (test) => {
 tape('Groupings', (test) => {
   test.equal(mathML('(a+b)'),
     '<mfenced open="(" close=")"><mi>a</mi><mo value="+">+</mo><mi>b</mi></mfenced>');
-  test.equal(mathML('{a+b}'),
-    '<mfenced open="{" close="}"><mi>a</mi><mo value="+">+</mo><mi>b</mi></mfenced>');
   test.equal(mathML('abs(a+b)'),
     '<mfenced open="|" close="|"><mi>a</mi><mo value="+">+</mo><mi>b</mi></mfenced>');
   test.equal(mathML('a,b,c'),
@@ -142,5 +140,33 @@ tape('Groupings', (test) => {
     '<msup><mi>e</mi><mrow><mo value="−">−</mo><mi>x</mi></mrow></msup>');
   test.equal(mathML('e^(i tau) = 1'),
     '<msup><mi>e</mi><mrow><mi>i</mi><mi>τ</mi></mrow></msup><mo value="=">=</mo><mn>1</mn>');
+  test.end();
+});
+
+tape('Matrices and Piecewise', (test) => {
+  test.equal(mathML('[a, b, c]'),
+    '<mfenced open="[" close="]" rows="1"><mi>a</mi><mi>b</mi><mi>c</mi></mfenced>');
+  test.equal(mathML('[a, b; c, d]'),
+    '<mfenced open="[" close="]" rows="2"><mi>a</mi><mi>b</mi><mi>c</mi><mi>d</mi></mfenced>');
+  test.equal(mathML('[a; b; c]'),
+    '<mfenced open="[" close="]" rows="3"><mi>a</mi><mi>b</mi><mi>c</mi></mfenced>');
+  test.equal(mathML('{a, b, c}'),
+    '<mfenced open="{" close="}" rows="1"><mi>a</mi><mi>b</mi><mi>c</mi></mfenced>');
+  test.equal(mathML('{a, b; c, d}'),
+    '<mfenced open="{" close="}" rows="2"><mi>a</mi><mi>b</mi><mi>c</mi><mi>d</mi></mfenced>');
+  test.equal(mathML('{a; b; c}'),
+    '<mfenced open="{" close="}" rows="3"><mi>a</mi><mi>b</mi><mi>c</mi></mfenced>');
+  test.equal(mathML('{a+b}'),
+    '<mfenced open="{" close="}" rows="1"><mi>a</mi><mo value="+">+</mo><mi>b</mi></mfenced>');
+  test.end();
+});
+
+tape('Under Over', (test) => {
+  test.equal(mathML('∑_(i = 0)^2 i'),
+    '<munderover><mo value="∑">∑</mo><mrow><mi>i</mi><mo value="=">=</mo><mn>0</mn>∫</mrow><mn>2</mn></munderover><mi>i</mi>');
+  test.equal(mathML('∫_a^b c'),
+    '<munderover><mo value="∫">∫</mo><mi>a</mi><mi>b</mi></munderover><mi>c</mi>');
+  test.equal(mathML('∫_0^1 xdx'),
+    '<munderover><mo value="∫">∫</mo><mn>0</mn><mn>1</mn></munderover><mi>xdx</mi>');
   test.end();
 });

--- a/test/voice-test.ts
+++ b/test/voice-test.ts
@@ -13,6 +13,8 @@ const voice = (src: string) => Expression.parse(src).toVoice();
 
 tape('Basic Voice', (test) => {
   test.equal(voice('sqrt(5)'), 'square root of 5');
+  test.equal(voice('root(27, 3)'), 'cubic root of 27');
+  test.equal(voice('root(256, 4)'), '4th root of 256');
   test.equal(voice('a * b'), '_a_ times _b_');
   test.equal(voice('(a * b)'), '_a_ times _b_');
   test.equal(voice('a^b'), '_a_ to the power of _b_');

--- a/test/voice-test.ts
+++ b/test/voice-test.ts
@@ -25,5 +25,14 @@ tape('Basic Voice', (test) => {
   test.equal(voice('a/b'), '_a_ over _b_');
   test.equal(voice('a//b'), '_a_ divided by _b_');
   test.equal(voice('(a + b)/cc'), '_a_ plus _b_ over cc');
+  test.equal(voice('∑_(i=1)^(10)'), 'sum from _i_ equals 1 to 10 of');
+  test.equal(voice('∑_(i=1)^(10)i'), 'sum from _i_ equals 1 to 10 of _i_');
+  test.equal(voice('∑_(i=1)^(10)i + 1'), 'sum from _i_ equals 1 to 10 of _i_ plus 1');
+  test.equal(voice('∏_(i=1)^(10)'), 'product from _i_ equals 1 to 10 of');
+  test.equal(voice('∏_(i=1)^(10)i'), 'product from _i_ equals 1 to 10 of _i_');
+  test.equal(voice('∏_(i=1)^(10)i + 1'), 'product from _i_ equals 1 to 10 of _i_ plus 1');
+  test.equal(voice('∫_(i=1)^(10)'), 'integral from _i_ equals 1 to 10 of');
+  test.equal(voice('∫_(i=1)^(10)i'), 'integral from _i_ equals 1 to 10 of _i_');
+  test.equal(voice('∫_(i=1)^(10)i + 1'), 'integral from _i_ equals 1 to 10 of _i_ plus 1');
   test.end();
 });


### PR DESCRIPTION
Adds support for matrices (using `[  ]`) and piece-wise functions (using `{}`). For both, semi-colons are used to indicate column breaks.

Further adds support for tokenization and MathML of underover elements (sum, product, integral).

TODO: evaluation of all the above