### PR TITLE
Negative parsing fix

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -8,7 +8,7 @@ import {flatten, isOneOf, join, repeat, unique, words} from '@mathigon/core';
 import {evaluate, interval, Interval} from './eval';
 import {collapseTerm} from './parser';
 import {BRACKETS, escape, isSpecialFunction, VOICE_STRINGS} from './symbols';
-import {CustomFunction, ExprElement, ExprMap, ExprNumber, MathMLMap, VarMap} from './elements';
+import {ExprElement, ExprMap, ExprNumber, MathMLMap, VarMap} from './elements';
 import {ExprError} from './errors';
 
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -296,6 +296,14 @@ export function collapseTerm(tokens: ExprElement[]): ExprElement {
     }
   }
 
+  // Replace all operator minuses with functions. Each function takes only one argument, the next token in sequence.
+  for (let i = 0; i < tokens.length - 1; i++) {
+    // Minus, hyphen-minus, hyphen and dash are different symbols. We replace them all with same minus char.
+    if (isOperator(tokens[i], '− - ‐ –')) {
+      tokens.splice(i, 2, new ExprFunction('−', [tokens[i + 1]]));
+    }
+  }
+
   // Match multiplication operators.
   tokens = findAssociativeFunction(tokens, '× * ·', true);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -169,7 +169,6 @@ function findBinaryLeadingMinus(tokens: ExprElement[]) {
   for (let i = 1; i < tokens.length; i++) {
     const token = tokens[i];
     if (token instanceof ExprFunction && token.fn === '−') {
-      // const a = tokens[i - 1] || 0; // Default previous value to 0 if no previous token.
       const a = tokens[i - 1];
       const b = token.args[0];
 

--- a/test/evaluate-test.ts
+++ b/test/evaluate-test.ts
@@ -34,6 +34,8 @@ tape('Functions', (test) => {
 tape('Order and Brackets', (test) => {
   test.equal(value('2 a b', {a: 3, b: 5}), 30);
   test.equal(value('2 +  3  + 5'), 10);
+  test.equal(value('2 - 3 - 5'), -6);
+  test.equal(value('-2 - 3 - 5'), -10);
   test.equal(value('2 + 3 * 5'), 17);
   test.equal(value('2 * 3 - 5'), 1);
   test.equal(value('2 * (5 - 3)'), 4);
@@ -41,6 +43,7 @@ tape('Order and Brackets', (test) => {
   test.equal(value('2 * (5 - 8 / 2)'), 2);
   test.equal(value('+ 2 + 3'), 5);
   test.equal(value('- 2 * 3'), -6);
+  test.equal(value('3 * - 2'), -6);
   test.end();
 });
 

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -59,8 +59,6 @@ tape('Comparison Operators', (test) => {
 });
 
 tape('Unary Minus', (test) => {
-  test.throws(() => expr('1 * -1').collapse());
-  test.throws(() => expr('1 + -1').collapse());
   test.doesNotThrow(() => expr('x = -1').collapse());
   test.end();
 });
@@ -93,7 +91,6 @@ tape('brackets', (test) => {
 
 tape('errors', (test) => {
   test.throws(() => expr('a + + b').collapse());
-  test.throws(() => expr('a * - b').collapse());
   test.throws(() => expr('a + (a +)').collapse());
   test.throws(() => expr('a + (*)').collapse());
   test.throws(() => expr('(+) - a').collapse());


### PR DESCRIPTION
Fixes parsing problems with consecutive operators, where one operator is a '-'. This led to expressions such as '2 x -3' being invalid.

TODO:

- [ ] Single number with leading minus is being evaluated (e.g. '-3' is evaluated and '-3' is displayed as a result)
- [ ] Treatment of +- (±) - what is expected output?