### PR TITLE
export ExprString

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
 
 export {ExprError} from './errors';
 export {Expression} from './expression';
-export {ExprElement, ExprIdentifier, ExprNumber, ExprOperator} from './elements';
+export {ExprElement, ExprIdentifier, ExprNumber, ExprOperator, ExprString} from './elements';
 export {ExprFunction} from './functions';
 export {CONSTANTS as HILBERT_CONSTANTS, SPECIAL_IDENTIFIERS, isSpecialFunction} from './symbols';
 export {hasZero, Interval, isWhole, width} from './eval';


### PR DESCRIPTION
The `ExprString` class is defined in `elements.ts` but not exported. It would be helpful to make it available for import. 